### PR TITLE
Add '/' in Function_name pattern

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -8,7 +8,7 @@ import (
 
 // Coder should use following naming convention for Benchmark functions
 // Naming convention: Benchmark[Function_name]_[Function_argument](b *testing.B)
-var re *regexp.Regexp = regexp.MustCompile(`Benchmark([a-zA-Z0-9]+)_([_a-zA-Z0-9]+)-([0-9]+)$`)
+var re *regexp.Regexp = regexp.MustCompile(`Benchmark([a-zA-Z0-9/]+)_([_a-zA-Z0-9]+)-([0-9]+)$`)
 
 // Storage for Func(Arg)=Result relations
 type BenchArgSet map[string]float64


### PR DESCRIPTION
It's possible to get '/' in the function name part when running sub-benchmarks